### PR TITLE
revert rust to v1.43

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,12 +1,12 @@
-{% set version = "1.48.0" %}
+{% set version = "1.43.0" %}
 
 package:
   name: rust-nightly
   version: {{ version }}
 
 source:
-  url: https://static.rust-lang.org/dist/2020-08-29/rust-nightly-x86_64-unknown-linux-gnu.tar.gz  # [linux and x86_64]
-  url: https://static.rust-lang.org/dist/2020-08-29/rust-nightly-powerpc64le-unknown-linux-gnu.tar.gz  # [ppc64le]
+  url: https://static.rust-lang.org/dist/2020-02-20/rust-nightly-x86_64-unknown-linux-gnu.tar.gz  # [linux and x86_64]
+  url: https://static.rust-lang.org/dist/2020-02-20/rust-nightly-powerpc64le-unknown-linux-gnu.tar.gz  # [ppc64le]
 
 build:
   number: 1


### PR DESCRIPTION
Revert rust to older version - `v1.43.0` to fix the following build error observed on x86 in `tokenizers` recipe.

```
error: the legacy LLVM-style asm! syntax is no longer supported
  --> /home/builder/.cargo/registry/src/github.com-1ecc6299db9ec823/parking_lot-0.10.0/src/elision.rs:77:13
   |
77 |               asm!("xacquire; lock; cmpxchgq $2, $1"
   |               ^---
   |               |
   |  _____________help: replace with: `llvm_asm!`
   | |
78 | |                  : "={rax}" (prev), "+*m" (self)
79 | |                  : "r" (new), "{rax}" (current)
80 | |                  : "memory"
81 | |                  : "volatile");
   | |_______________________________^
   |
   = note: consider migrating to the new asm! syntax specified in RFC 2873
   = note: alternatively, switch to llvm_asm! to keep your code working as it is

error: the legacy LLVM-style asm! syntax is no longer supported
   --> /home/builder/.cargo/registry/src/github.com-1ecc6299db9ec823/parking_lot-0.10.0/src/elision.rs:108:13
    |
108 |               asm!("xrelease; lock; xaddq $2, $1"
    |               ^---
    |               |
    |  _____________help: replace with: `llvm_asm!`
    | |
109 | |                  : "=r" (prev), "+*m" (self)
110 | |                  : "0" (val.wrapping_neg())
111 | |                  : "memory"
112 | |                  : "volatile");
    | |_______________________________^
    |
    = note: consider migrating to the new asm! syntax specified in RFC 2873
    = note: alternatively, switch to llvm_asm! to keep your code working as it is
```